### PR TITLE
Add onCopy function to CopyBlock component

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -62,6 +62,7 @@ function App() {
           language="go"
           text={`v := Vertex{X: 1, Y: 2}`}
           theme={selectedTheme}
+          onCopy={() => alert("Copied code block!")}
         />
       </div>
       <GithubCorner href="https://github.com/rajinwonderland/react-code-blocks" />

--- a/packages/react-code-blocks/README.md
+++ b/packages/react-code-blocks/README.md
@@ -143,9 +143,10 @@ function MyCoolCodeBlock({ code, language, showLineNumbers }) {
 
 Same as the `CodeBlock`'s component with the exception of one!
 
-| name        | type      | default | description                                                                                          |
-| ----------- | --------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `codeBlock` | `boolean` | `false` | Indicates whether to render the `CopyBlock` as an inline `Code` component or a `CodeBlock` component |
+| name        | type       | default | description                                                                                                                       |
+| ----------- | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `codeBlock` | `boolean`  | `false` | Indicates whether to render the `CopyBlock` as an inline `Code` component or a `CodeBlock` component                              |
+| `onCopy`    | `function` | -       | The onCopy function is called if the copy icon is clicked. This enables you to add a custom message that the code block is copied |
 
 ## Supported Themes
 

--- a/packages/react-code-blocks/src/components/CopyBlock.tsx
+++ b/packages/react-code-blocks/src/components/CopyBlock.tsx
@@ -20,6 +20,9 @@ export interface Props {
   /** This is a prop used internally by the `CopyBlock`'s button component to toggle the icon to a success icon */
   copied: boolean;
 
+  /** The onCopy function is called if the copy icon is clicked. This enables you to add a custom message that the code block is copied. */
+  onCopy: Function,
+
   /** The language in which the code is written. [See LANGUAGES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/LANGUAGES.md) */
 
   language: string;
@@ -67,13 +70,14 @@ export default function CopyBlock({
   text,
   codeBlock = false,
   customStyle = {},
+  onCopy,
   ...rest
 }: Props) {
   const [copied, toggleCopy] = useState(false);
   const { copy } = useClipboard();
   const handler = () => {
     copy(text);
-    toggleCopy(!copied);
+    onCopy ? onCopy() : toggleCopy(!copied);
   };
 
   return (


### PR DESCRIPTION
Hi @rajinwonderland. I wanted to use `react-code-blocks` in one of my projects but wanted to use my messaging system to show the user that the code block is copied. Therefore, I added the `onCopy` property to the `CopyBlock` component. Please take a look at it and merge it if you are fine with it. 

PS: I am not sure where I have to update the readme. Just in the `react-code-blocks` package or also the global version of it? (It seems to be the same in both places)