### PR TITLE
move typescript-plugin-styled-components from dependencies to devDependencies

### DIFF
--- a/packages/react-code-blocks/package.json
+++ b/packages/react-code-blocks/package.json
@@ -68,13 +68,13 @@
     "react-dom": "^16.13.1",
     "ts-loader": "^6.2.2",
     "tsdx": "^0.13.2",
-    "typescript": "^3.9.6"
+    "typescript": "^3.9.6",
+    "typescript-plugin-styled-components": "^1.4.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
     "react-syntax-highlighter": "^12.2.1",
     "styled-components": "^5.1.1",
-    "tslib": "^2.0.0",
-    "typescript-plugin-styled-components": "^1.4.4"
+    "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
typescript-plugin-styled-components should not be installed when projects are depending on react-code-blocks since it is only required for development.

fixes #28 