### PR TITLE
Ability to set the starting line number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ function MyCodeComponent(props) {
       text={props.code}
       language={props.language}
       showLineNumbers={props.showLineNumbers}
+      startingLineNumber={props.startingLineNumber}
       wrapLines
     />
   );
@@ -94,12 +95,13 @@ A simple code block component
 ```js
 import { CodeBlock, dracula } from "react-code-blocks";
 
-function MyCoolCodeBlock({ code, language, showLineNumbers }) {
+function MyCoolCodeBlock({ code, language, showLineNumbers, startingLineNumber }) {
   return (
     <CodeBlock
       text={code}
       language={language}
       showLineNumbers={showLineNumbers}
+      startingLineNumber={startingLineNumber}
       theme={dracula}
     />
   );
@@ -115,6 +117,7 @@ function MyCoolCodeBlock({ code, language, showLineNumbers }) {
 | `text`            | `string`  | **required** | The code to be formatted                                                                                                                                       |
 | `language`        | `string`  | "text"       | The language in which the code is written. [See here](LANGUAGES.md) for a list of supported languages                                                          |
 | `showLineNumbers` | `boolean` | `true`       | Indicates whether or not to show line numbers                                                                                                                  |
+| `startingLineNumber` | `number` | `1`       | if `showLineNumbers` is enabled the line numbering will start from here.                                                                                                                  |
 | `theme`           | `object`  | **dracula**  | A theme object for the code block. [See here](THEMES.md) for a list of supported themes                                                                        |  |
 | `highlight`       | `string`  | ""           | Lines to highlight! For multiple lines, use a comma i.e `highlight="1,6,7"`. For a range of lines, use a `-` i.e `highlight="1-5"` for highlighting lines 1-5. |
 
@@ -129,11 +132,12 @@ A code block component with a little copy button for copying a snippet.
 ```jsx
 import { CopyBlock, dracula } from "react-code-blocks";
 
-function MyCoolCodeBlock({ code, language, showLineNumbers }) {
+function MyCoolCodeBlock({ code, language, showLineNumbers, startingLineNumber }) {
   <CopyBlock
     text={code}
     language={language}
     showLineNumbers={showLineNumbers}
+    startingLineNumber={startingLineNumber}
     theme={dracula}
     codeBlock
   />;

--- a/packages/react-code-blocks/src/components/Code.tsx
+++ b/packages/react-code-blocks/src/components/Code.tsx
@@ -21,6 +21,8 @@ export interface CodeProps {
   preTag: Node | string;
   /** Indicates whether or not to show line numbers */
   showLineNumbers: boolean;
+  /**For choosing starting line**/
+  startingLineNumber :number;
   /** The code to be formatted */
   text: string;
   /** A custom theme to be applied, implements the `CodeBlockTheme` interface. You can also pass pass a precomposed theme into here. For available themes. [See THEMES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/THEMES.md) */
@@ -42,6 +44,7 @@ export default class Code extends PureComponent<CodeProps, {}> {
   static defaultProps = {
     theme: {},
     showLineNumbers: false,
+    startingLineNumber : 1,
     lineNumberContainerStyle: {},
     codeTagProps: {},
     preTag: 'span',
@@ -99,6 +102,7 @@ export default class Code extends PureComponent<CodeProps, {}> {
       PreTag: this.props.preTag,
       style: this.props.codeStyle || inlineCodeStyle,
       showLineNumbers: this.props.showLineNumbers,
+      startingLineNumber: this.props.startingLineNumber ,
       codeTagProps: this.props.codeTagProps,
     };
 

--- a/packages/react-code-blocks/src/components/CodeBlock.tsx
+++ b/packages/react-code-blocks/src/components/CodeBlock.tsx
@@ -10,6 +10,10 @@ export interface CodeBlockProps {
   language: string;
   /** Indicates whether or not to show line numbers */
   showLineNumbers?: boolean;
+
+  /**startingLineNumber - if showLineNumbers is enabled the line numbering will start from here.**/
+  startingLineNumber :number;
+
   /** A custom theme to be applied, implements the `CodeBlockTheme` interface. You can also pass pass a precomposed theme into here. For available themes. [See THEMES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/THEMES.md) */
   theme?: Theme;
   /** The element or custom react component to use in place of the default `span` tag */
@@ -43,6 +47,7 @@ export default class CodeBlock extends PureComponent<CodeBlockProps, {}> {
 
   static defaultProps = {
     showLineNumbers: true,
+    startingLineNumber : 1,
     language: LANGUAGE_FALLBACK,
     theme: {},
     highlight: '',
@@ -91,6 +96,7 @@ export default class CodeBlock extends PureComponent<CodeBlockProps, {}> {
       },
       customStyle: this.props?.customStyle,
       showLineNumbers: this.props.showLineNumbers,
+      startingLineNumber : this.props.startingLineNumber ,
       codeTagProps: {
         style: {
           ...codeContainerStyle,


### PR DESCRIPTION
CodeBlock "startingLineNumber" prop to set the first line number in the snippet, defaults to 1.
If `showLineNumbers` is enabled the line numbering will start from here.