### PR TITLE
soft wrap long lines

### DIFF
--- a/packages/react-code-blocks/package.json
+++ b/packages/react-code-blocks/package.json
@@ -60,7 +60,7 @@
     "@types/he": "^1.1.1",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.7",
-    "@types/react-syntax-highlighter": "^11.0.4",
+    "@types/react-syntax-highlighter": "^13.5.0",
     "@types/styled-components": "^5.1.0",
     "enzyme": "^3.11.0",
     "react": "^16.13.1",
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
-    "react-syntax-highlighter": "^12.2.1",
+    "react-syntax-highlighter": "^15.4.3",
     "styled-components": "^5.1.1",
     "tslib": "^2.0.0"
   }

--- a/packages/react-code-blocks/src/components/Code.tsx
+++ b/packages/react-code-blocks/src/components/Code.tsx
@@ -28,6 +28,9 @@ export interface CodeProps {
   /** A custom theme to be applied, implements the `CodeBlockTheme` interface. You can also pass pass a precomposed theme into here. For available themes. [See THEMES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/THEMES.md) */
   theme?: Theme;
 
+  /** If true, wrap long lines */
+  wrapLongLines: boolean;
+
   /**
    * Lines to highlight comma delimited.
    * Example uses:
@@ -44,6 +47,7 @@ export default class Code extends PureComponent<CodeProps, {}> {
   static defaultProps = {
     theme: {},
     showLineNumbers: false,
+    wrapLongLines: false,
     startingLineNumber : 1,
     lineNumberContainerStyle: {},
     codeTagProps: {},
@@ -104,6 +108,7 @@ export default class Code extends PureComponent<CodeProps, {}> {
       showLineNumbers: this.props.showLineNumbers,
       startingLineNumber: this.props.startingLineNumber ,
       codeTagProps: this.props.codeTagProps,
+      wrapLongLines: this.props.wrapLongLines
     };
 
     return (

--- a/packages/react-code-blocks/src/components/CodeBlock.tsx
+++ b/packages/react-code-blocks/src/components/CodeBlock.tsx
@@ -27,6 +27,9 @@ export interface CodeBlockProps {
   /** The style object that will be combined with the top level style on the pre tag, styles here will overwrite earlier styles. */
   customStyle?: {};
 
+  /** If true, wrap long lines */
+  wrapLongLines: boolean;
+
   /**
    * Lines to highlight comma delimited.
    * Example uses:
@@ -47,6 +50,7 @@ export default class CodeBlock extends PureComponent<CodeBlockProps, {}> {
 
   static defaultProps = {
     showLineNumbers: true,
+    wrapLongLines: false,
     startingLineNumber : 1,
     language: LANGUAGE_FALLBACK,
     theme: {},
@@ -109,6 +113,7 @@ export default class CodeBlock extends PureComponent<CodeBlockProps, {}> {
       },
       text: this.props.text.toString(),
       highlight: this.props.highlight,
+      wrapLongLines: this.props.wrapLongLines
     };
 
     return <Code {...props} />;

--- a/packages/react-code-blocks/src/components/CopyBlock.tsx
+++ b/packages/react-code-blocks/src/components/CopyBlock.tsx
@@ -20,6 +20,9 @@ export interface Props {
   /** This is a prop used internally by the `CopyBlock`'s button component to toggle the icon to a success icon */
   copied: boolean;
 
+  /** If true, wrap long lines */
+  wrapLongLines: boolean;
+
   /** The onCopy function is called if the copy icon is clicked. This enables you to add a custom message that the code block is copied. */
   onCopy: Function,
 

--- a/packages/react-code-blocks/stories/CopyBlock.stories.tsx
+++ b/packages/react-code-blocks/stories/CopyBlock.stories.tsx
@@ -32,6 +32,7 @@ df.head(5)`
   );
   const themes = select('theme', themeObj, 'dracula');
   const showLineNumbers = boolean('showLineNumbers', true);
+  const wrapLongLines = boolean('wrapLongLines', false);
   const codeBlock = boolean('codeBlock', true);
   return (
     <div
@@ -43,6 +44,7 @@ df.head(5)`
         text={he.decode(code)}
         language={language}
         theme={require('../src')[themes]}
+        wrapLongLines={wrapLongLines}
         {...{ showLineNumbers, codeBlock }}
       />
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,6 +2848,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hast@^2.0.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"
+  integrity sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/he@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/he/-/he-1.1.1.tgz#19e14033c4ee8f1a702c74dcc6182664839ac2b7"
@@ -3004,10 +3011,17 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@11.0.4", "@types/react-syntax-highlighter@^11.0.4":
+"@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
   integrity sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-syntax-highlighter@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-13.5.0.tgz#b93c05f28844e7c35a5f1d38d3819099ffa82fbd"
+  integrity sha512-U7DrUaQRv3b+fsbPXMf7vC21K7DOkdNCQtp14Wm0Z5YLI9fPhndN4YTZ9eVXwmAivIg6lZ3YBVtGYucAS3H76A==
   dependencies:
     "@types/react" "*"
 
@@ -8691,7 +8705,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fault@^1.0.2:
+fault@^1.0.0, fault@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
   integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
@@ -10491,6 +10505,17 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
 he@1.2.x, he@^1.1.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -10508,6 +10533,11 @@ hicat@^0.7.0:
   dependencies:
     highlight.js "^8.1.0"
     minimist "^0.2.0"
+
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 highlight.js@^8.1.0:
   version "8.9.1"
@@ -13633,6 +13663,14 @@ lowlight@1.12.1:
     fault "^1.0.2"
     highlight.js "~9.15.0"
 
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
+
 lowlight@~1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.11.0.tgz#1304d83005126d4e8b1dc0f07981e9b689ec2efc"
@@ -16561,6 +16599,13 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
+prismjs@^1.22.0, prismjs@~1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 prismjs@^1.8.4:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"
@@ -17077,6 +17122,17 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+react-code-blocks@*:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/react-code-blocks/-/react-code-blocks-0.0.8.tgz#3bb70b9b60510dba6c6b7ef350d1977cf022ff15"
+  integrity sha512-xGw05QLvaEteWnlmPKr7pe/F7WrhUT7GbL5h+Yf3zmErVDmZJbQgJVxSnDSEw30V32fo4EFb8wo/3mhO4pZSsw==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    react-syntax-highlighter "^12.2.1"
+    styled-components "^5.1.1"
+    tslib "^2.0.0"
+    typescript-plugin-styled-components "^1.4.4"
+
 react-color@^2.17.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"
@@ -17492,6 +17548,17 @@ react-syntax-highlighter@^12.2.1:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
+react-syntax-highlighter@^15.4.3:
+  version "15.4.3"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz#fffe3286677ac470b963b364916d16374996f3a6"
+  integrity sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.22.0"
+    refractor "^3.2.0"
+
 react-textarea-autosize@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz#70fdb333ef86bcca72717e25e623e90c336e2cda"
@@ -17727,6 +17794,15 @@ refractor@^2.4.1:
     hastscript "^5.0.0"
     parse-entities "^1.1.2"
     prismjs "~1.17.0"
+
+refractor@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.3.1.tgz#ebbc04b427ea81dc25ad333f7f67a0b5f4f0be3a"
+  integrity sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.23.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
Original issue: https://github.com/rajinwonderland/react-code-blocks/issues/30

Note that
1. dependency `react-syntax-highlighter` is upgraded from v12 to v15 because this feature requires the `wrapLongLines` which is not available til v14.
2. the dependency `react-syntax-highlighter` has some display issues when both `wrapLongLines` and `showLineNumbers` are set to true. This can be found here: https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/402
