### PR TITLE
Fix contributor badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <p align="center"><img src="packages/assets/alt.png"></p>
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <h1 align="center">Welcome to <code>react-code-blocks</code> 👋👋👋</h1>
 <p>


### PR DESCRIPTION
The contributor badge in the README is not being rendered as an image, rather just text for me:

<img width="909" alt="Screen Shot 2021-06-17 at 12 04 36 AM" src="https://user-images.githubusercontent.com/1845314/122329545-a0853980-ceff-11eb-8851-7c75beb59932.png">

This is because the image requires a newline between it and the comment above for whatever reason. I also updated the number in the badge to `4` to match the number of people in the contributors section.