### PR TITLE
chore: Add YAML to list of supported languages

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -87,3 +87,4 @@ The following languages are supported:
 - vhdl
 - xml
 - xquery
+- yaml


### PR DESCRIPTION
## Description

YAML is not on the list, however it is in fact supported. I have incorporated this library into my blog and setting `yaml` as the value for `language` in the `CopyBlock` works as desired.

> Note: I did notice that the [contributing guidelines](https://github.com/rajinwonderland/react-code-blocks/blob/a52e9fa8e786e5304a43c0095294f05fc38b5eca/CONTRIBUTING.md) for this repo is a WIP, so take pity on made-up PR template.

## Demonstration 

You can find an example of YAML working happily on my blog [(with an example post here)](https://blog.dennisokeeffe.com/blog/2019-04-22-intro-to-helm) where I have gladly incorporated this package.