### PR TITLE
Add Typed Props To Themed Exported Components

### DIFF
--- a/packages/react-code-blocks/src/ThemedCode.tsx
+++ b/packages/react-code-blocks/src/ThemedCode.tsx
@@ -1,9 +1,9 @@
 import React, { PropsWithChildren } from 'react';
 import { withTheme } from 'styled-components';
-import Code from './components/Code';
+import Code, { CodeProps } from './components/Code';
 
 const CodeWithTheme = withTheme(Code);
 
-export default function(props: PropsWithChildren<any>) {
+export default function(props: PropsWithChildren<CodeProps>) {
   return <CodeWithTheme {...props} />;
 }

--- a/packages/react-code-blocks/src/ThemedCodeBlock.tsx
+++ b/packages/react-code-blocks/src/ThemedCodeBlock.tsx
@@ -1,9 +1,9 @@
 import React, { PropsWithChildren } from 'react';
 import { withTheme } from 'styled-components';
-import CodeBlock from './components/CodeBlock';
+import CodeBlock, { CodeBlockProps } from './components/CodeBlock';
 
 const CodeBlockWithTheme = withTheme(CodeBlock);
 
-export default function(props: PropsWithChildren<any>) {
+export default function(props: PropsWithChildren<CodeBlockProps>) {
   return <CodeBlockWithTheme {...props} />;
 }

--- a/packages/react-code-blocks/src/ThemedCopyBlock.tsx
+++ b/packages/react-code-blocks/src/ThemedCopyBlock.tsx
@@ -1,8 +1,8 @@
 import React, { PropsWithChildren } from 'react';
 import { withTheme } from 'styled-components';
-import CopyBlock from './components/CopyBlock';
+import CopyBlock, { CopyBlockProps } from './components/CopyBlock';
 const CopyBlockWithTheme = withTheme(CopyBlock);
 
-export default function(props: PropsWithChildren<any>) {
+export default function(props: PropsWithChildren<CopyBlockProps>) {
   return <CopyBlockWithTheme {...props} />;
 }

--- a/packages/react-code-blocks/src/ThemedSnippet.tsx
+++ b/packages/react-code-blocks/src/ThemedSnippet.tsx
@@ -1,3 +1,4 @@
+import { SnippetProps } from 'components/Snippet/Snippet';
 import React, { PropsWithChildren } from 'react';
 import { withTheme } from 'styled-components';
 import Snippet from './components/Snippet';
@@ -5,6 +6,6 @@ import Snippet from './components/Snippet';
 // @ts-ignore
 const SnippetWithTheme = withTheme(Snippet);
 
-export default function(props: PropsWithChildren<any>) {
+export default function(props: PropsWithChildren<SnippetProps>) {
   return <SnippetWithTheme {...props} />;
 }

--- a/packages/react-code-blocks/src/components/CopyBlock.tsx
+++ b/packages/react-code-blocks/src/components/CopyBlock.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Theme } from '../types';
 import useClipboard from '../hooks/use-clipboard';
 
-export interface Props {
+export interface CopyBlockProps {
   /** A custom theme to be applied, implements the `CodeBlockTheme` interface. You can also pass pass a precomposed theme into here. For available themes. [See THEMES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/THEMES.md) */
   theme: Theme;
 
@@ -34,7 +34,7 @@ export interface Props {
   [x: string]: any;
 }
 
-const Button = styled.button<Props>`
+const Button = styled.button<CopyBlockProps>`
   position: absolute;
   top: 0.5em;
   right: 0.75em;
@@ -61,7 +61,7 @@ const Button = styled.button<Props>`
   }
 `;
 
-const Snippet = styled.div<Props>`
+const Snippet = styled.div<CopyBlockProps>`
   position: relative;
   background: ${p => p.theme.backgroundColor};
   border-radius: 0.25rem;
@@ -75,7 +75,7 @@ export default function CopyBlock({
   customStyle = {},
   onCopy,
   ...rest
-}: Props) {
+}: CopyBlockProps) {
   const [copied, toggleCopy] = useState(false);
   const { copy } = useClipboard();
   const handler = () => {


### PR DESCRIPTION
The themed components exported at the package level do not have typed props. This means that TS can't to figure out the props and will created unsafe errors. Adding the typed props should fix this.

Resolving Issue #50 