### PR TITLE
Update cs to csharp

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -10,7 +10,7 @@ The following languages are supported:
 - c
 - clojure
 - cs
-- c
+- c#
 - cpp
 - coffeescript
 - csharp

--- a/packages/react-code-blocks/src/utils/normalizeLanguage.ts
+++ b/packages/react-code-blocks/src/utils/normalizeLanguage.ts
@@ -11,8 +11,8 @@ export const SUPPORTED_LANGUAGE_ALIASES = Object.freeze([
   },
   {
     name: 'CSharp',
-    alias: ['csharp', 'c#'],
-    value: 'cs',
+    alias: ['csharp', 'c#', 'cs'],
+    value: 'csharp',
   },
   {
     name: 'Python',


### PR DESCRIPTION
Passing `c#` or `csharp` as the language prop results in the error "Language cs not supported". I believe this is because react-syntax-highlighter is expecting `csharp` rather than `cs`: https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD

https://github.com/rajinwonderland/react-code-blocks/issues/55