### PR TITLE
Update MDX.md

### DIFF
--- a/MDX.md
+++ b/MDX.md
@@ -37,10 +37,9 @@ const CustomCodeBlock = (props) => {
 
   const { className, copy, children } = props;
 
-  const language =
-    className?.split("-")[0] === "language"
-      ? className.split("-")[1]
-      : "javascript";
+  const language = className.match(/(?<=language-)(\w.*?)\b/) != null
+    ? className.match(/(?<=language-)(\w.*?)\b/)[0]
+    : "javascript";
 
   return copy ? (
     <CopyBlock


### PR DESCRIPTION
Current example breaks if the code block has more than one class. This uses a regex to make it more robust to this circumstance.

Couple regex test cases: https://regexr.com/6dcg8

Love the package!



