### PR TITLE
Updates the type signature of onCopy

### DIFF
--- a/packages/react-code-blocks/src/components/CopyBlock.tsx
+++ b/packages/react-code-blocks/src/components/CopyBlock.tsx
@@ -78,7 +78,7 @@ export default function CopyBlock({
 }: CopyBlockProps) {
   const [copied, toggleCopy] = useState(false);
   const { copy } = useClipboard();
-  const handler = () => {
+  const handler = (event: React.MouseEvent<HTMLButtonElement>) => {
     copy(text);
     onCopy ? onCopy(event) : toggleCopy(!copied);
   };

--- a/packages/react-code-blocks/src/components/CopyBlock.tsx
+++ b/packages/react-code-blocks/src/components/CopyBlock.tsx
@@ -24,7 +24,7 @@ export interface CopyBlockProps {
   wrapLongLines: boolean;
 
   /** The onCopy function is called if the copy icon is clicked. This enables you to add a custom message that the code block is copied. */
-  onCopy: Function,
+  onCopy: (event: React.MouseEvent<HTMLButtonElement>) => void;
 
   /** The language in which the code is written. [See LANGUAGES.md](https://github.com/rajinwonderland/react-code-blocks/blob/master/LANGUAGES.md) */
 
@@ -80,7 +80,7 @@ export default function CopyBlock({
   const { copy } = useClipboard();
   const handler = () => {
     copy(text);
-    onCopy ? onCopy() : toggleCopy(!copied);
+    onCopy ? onCopy(event) : toggleCopy(!copied);
   };
 
   return (


### PR DESCRIPTION
Passes the click event from the Copy button down to the onCopy prop,
allowing someone to do something like

```tsx
<CopyBlock onClick={e => e.preventDefault()} ... />
```

Or whatever other custom behavior that might require access to the click
event.