### PR TITLE
Csharp highlight fix 

### DIFF
--- a/packages/react-code-blocks/src/utils/normalizeLanguage.ts
+++ b/packages/react-code-blocks/src/utils/normalizeLanguage.ts
@@ -11,8 +11,8 @@ export const SUPPORTED_LANGUAGE_ALIASES = Object.freeze([
   },
   {
     name: 'CSharp',
-    alias: ['csharp', 'c#'],
-    value: 'cs',
+    alias: ['csharp', 'c#', 'cs'],
+    value: 'csharp',
   },
   {
     name: 'Python',


### PR DESCRIPTION
Problem arose from a fact that dependency react-syntax-highlighter doesn't accept 'cs' value as correct alias for csharp and therefore csharp highlight failed, correct alias is 'csharp'.

I am not sure if this pull request will fix package on npm as I couldn't find here 'dist' folder as .cjs files should be also updated for this fix to work, but I have created [repo](https://github.com/CROmartin/react-code-blocks-ls) with fixed npm package that will work and you can download it with this command **npm i https://github.com/CROmartin/react-code-blocks-ls/tarball/main**  