### PR TITLE
chore: update react-syntax-highlighter

### DIFF
--- a/packages/react-code-blocks/package.json
+++ b/packages/react-code-blocks/package.json
@@ -60,7 +60,7 @@
     "@types/he": "^1.1.1",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.7",
-    "@types/react-syntax-highlighter": "^13.5.0",
+    "@types/react-syntax-highlighter": "^15.5.6",
     "@types/styled-components": "^5.1.0",
     "enzyme": "^3.11.0",
     "react": "^16.13.1",
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
-    "react-syntax-highlighter": "^15.4.3",
+    "react-syntax-highlighter": "^15.5.0",
     "styled-components": "^5.1.1",
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
Fix a [high severity vulnerability](https://github.com/advisories/GHSA-3949-f494-cm99) in prismjs which was fixed in 1.27.0.
react-syntax-highligher 15.5.6 uses the fixed version.