### PR TITLE
chore: add repository url to workspace package.json

### DIFF
--- a/packages/react-code-blocks/package.json
+++ b/packages/react-code-blocks/package.json
@@ -13,6 +13,11 @@
   ],
   "version": "0.1.2",
   "homepage": "https://react-code-blocks.rajinwonderland.vercel.app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rajinwonderland/react-code-blocks",
+    "directory": "packages/react-code-blocks"
+  },
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Adds a repository URL to the package.json of the published npm package. Thus, a URL will be available to the GitHub Repo on npm.