### PR TITLE
Typo fix in lineNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ function MyCodeComponent(props) {
     text: props.code,
     language: props.language,
     showLineNumbers: props.showLineNumbers,
-    startingLineNUmber: props.startingLineNumber,
+    startingLineNumber: props.startingLineNumber,
     wrapLines: true,
   };
 


### PR DESCRIPTION
This fixes a typo in the code snippet provided in the Readme file.